### PR TITLE
feat: expand embed widths in individual blog posts

### DIFF
--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -62,7 +62,7 @@ const getTagClasses = (tag: string) => `
 
 <BaseLayout title={seoTitle || title} description={description} image={coverImage?.src || undefined}>
 	<div class='container'>
-		<main class='overflow-hidden mx-auto max-w-2xl'>
+		<main class='overflow-hidden mx-auto max-w-4xl'>
 			<article>
 				<Prose>
 					<div>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -122,9 +122,9 @@ const getTagClasses = (tag: string) => `
 			</article>
 
 			<div class='mt-8 space-y-8'>
-				<div>{headings.length > 0 && <TableOfContent headings={headings} />}</div>
+				<div class='mx-auto max-w-2xl'>{headings.length > 0 && <TableOfContent headings={headings} />}</div>
 
-				<div>
+				<div class='mx-auto max-w-2xl'>
 					{
 						GISCUS_REPO && (
 							<script

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -10,7 +10,27 @@
 
 @layer components {
 
-	/* Blog post view prose styles */
+	/* Blog post view prose styles - only for individual posts, not list view */
+	.prose:not(.list-view-prose) > *,
+	.prose:not(.list-view-prose) p,
+	.prose:not(.list-view-prose) ul,
+	.prose:not(.list-view-prose) ol,
+	.prose:not(.list-view-prose) blockquote,
+	.prose:not(.list-view-prose) h1,
+	.prose:not(.list-view-prose) h2,
+	.prose:not(.list-view-prose) h3,
+	.prose:not(.list-view-prose) h4,
+	.prose:not(.list-view-prose) h5,
+	.prose:not(.list-view-prose) h6 {
+		@apply mx-auto max-w-2xl;
+	}
+
+	/* Only content embeds in individual posts get wider treatment */
+	.prose:not(.list-view-prose) :where(img, iframe, video, pre):not(.prose > div img):not(.prose > div:first-child *):not(.prose > div:nth-child(2) *) {
+		@apply w-full max-w-none mx-0;
+	}
+
+	/* Ensure regular images still get proper spacing - both individual posts and list view */
 	.prose img {
 		@apply my-4;
 	}


### PR DESCRIPTION
Expands the container width for individual blog posts to allow images, videos, iframes, and code blocks to display at larger widths while maintaining readable text width for paragraphs and headings. Homepage and archive list views remain unchanged.

<img width="1728" height="1033" alt="image" src="https://github.com/user-attachments/assets/9db1604c-fae4-4063-8a31-f27a560e8447" />

<img width="1728" height="1036" alt="image" src="https://github.com/user-attachments/assets/43578b82-a520-4fce-8c1f-f7f9d74ab2dd" />

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>