### PR TITLE
feat: add home navigation links and remove header component

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,5 @@
 ---
 import BaseHead from './components/BaseHead.astro';
-import Header from './components/Header.astro';
 import Footer from './components/Footer.astro';
 import GradientHeader from './components/GradientHeader.astro';
 import 'src/styles/global.css';
@@ -15,9 +14,8 @@ const { title, description, image } = Astro.props;
 	<head>
 		<BaseHead title={title} description={description} image={image} />
 	</head>
-	<body class='bg-white dark:bg-zinc-900 dark:text-zinc-300 text-zinc-900 pt-16 sm:pt-0'>
+	<body class='bg-white dark:bg-zinc-900 dark:text-zinc-300 text-zinc-900'>
 		<GradientHeader>
-			<Header />
 			<div class='py-8 min-h-[calc(100vh-160px)]'>
 				<slot />
 			</div>

--- a/src/layouts/components/Header.astro
+++ b/src/layouts/components/Header.astro
@@ -38,39 +38,6 @@ const menu = [
 				<a class='p-3 hidden dark:block' href='https://github.com/arunsathiya' target='_blank'
 					><Image src={GithubWhite} width={24} height={24} alt='Github logo' /></a
 				>
-				<button class='p-3' id='themeToggle' aria-label='Theme mode'>
-					<svg
-						class='sun'
-						xmlns='http://www.w3.org/2000/svg'
-						width='24'
-						height='24'
-						viewBox='0 0 24 24'
-						fill='none'
-						stroke='currentColor'
-						stroke-width='2'
-						stroke-linecap='round'
-						stroke-linejoin='round'
-						class='lucide lucide-sun'
-						><circle cx='12' cy='12' r='4'></circle><path d='M12 2v2'></path><path d='M12 20v2'></path><path d='m4.93 4.93 1.41 1.41'
-						></path><path d='m17.66 17.66 1.41 1.41'></path><path d='M2 12h2'></path><path d='M20 12h2'></path><path
-							d='m6.34 17.66-1.41 1.41'></path><path d='m19.07 4.93-1.41 1.41'></path></svg
-					>
-					<svg
-						class='moon'
-						xmlns='http://www.w3.org/2000/svg'
-						width='24'
-						height='24'
-						viewBox='0 0 24 24'
-						fill='none'
-						stroke='currentColor'
-						stroke-width='2'
-						stroke-linecap='round'
-						stroke-linejoin='round'
-						class='lucide lucide-moon'
-					>
-						<path d='M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z'></path></svg
-					>
-				</button>
 			</div>
 		</nav>
 		<div class='fixed top-3 w-auto max-w-full px-3 left-1/2 -translate-x-1/2 z-[999]'>

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -63,16 +63,16 @@ const getTagClasses = (tag: string) => `
 <BaseLayout title={seoTitle || title} description={description} image={coverImage?.src || undefined}>
 	<div class='container'>
 		<main class='overflow-hidden mx-auto max-w-4xl'>
-			<div class='mb-6'>
-				<a href='/' class='inline-flex items-center gap-2 text-zinc-700 dark:text-zinc-300 hover:text-zinc-950 dark:hover:text-zinc-100 transition-colors'>
-					<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
-						<path d='M19 12H5M12 19l-7-7 7-7'></path>
-					</svg>
-					Home
-				</a>
-			</div>
 			<article>
 				<Prose>
+					<div class='mb-6'>
+						<a href='/' class='inline-flex items-center gap-2 text-zinc-700 dark:text-zinc-300 hover:text-zinc-950 dark:hover:text-zinc-100 transition-colors'>
+							<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+								<path d='M19 12H5M12 19l-7-7 7-7'></path>
+							</svg>
+							Home
+						</a>
+					</div>
 					<div>
 						<h1 class='!my-1 leading-tight'>{title}</h1>
 						<div

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -63,6 +63,14 @@ const getTagClasses = (tag: string) => `
 <BaseLayout title={seoTitle || title} description={description} image={coverImage?.src || undefined}>
 	<div class='container'>
 		<main class='overflow-hidden mx-auto max-w-4xl'>
+			<div class='mb-6'>
+				<a href='/' class='inline-flex items-center gap-2 text-zinc-700 dark:text-zinc-300 hover:text-zinc-950 dark:hover:text-zinc-100 transition-colors'>
+					<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+						<path d='M19 12H5M12 19l-7-7 7-7'></path>
+					</svg>
+					Home
+				</a>
+			</div>
 			<article>
 				<Prose>
 					<div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,7 +24,13 @@ const posts = (await getCollection('blog'))
 		<main>
 			<div class='mt-6 mb-12'>
 				<div class='flex justify-between gap-2 border-b mb-1 dark:border-b-zinc-700'>
-					<h2 class='text-lg font-bold mb-3'>Posts</h2>
+					<a href='/' class='inline-flex items-center gap-2 text-lg font-bold mb-3 text-zinc-950 dark:text-zinc-100 hover:text-zinc-700 dark:hover:text-zinc-300 transition-colors'>
+						<svg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+							<path d='M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8'></path>
+							<path d='M3 10a2 2 0 0 1 .709-1.528l7-5.999a2 2 0 0 1 2.582 0l7 5.999A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z'></path>
+						</svg>
+						Home
+					</a>
 					<a href='/posts/' class='inline-block py-2 underline text-zinc-950 dark:text-zinc-100'>All posts &raquo;</a>
 				</div>
 				<div>

--- a/src/pages/posts/[page].astro
+++ b/src/pages/posts/[page].astro
@@ -68,6 +68,14 @@ if (currentPage < 1 || currentPage > totalPages) {
 <BaseLayout title={title} description={description}>
     <div class='container'>
         <div class='mb-10'>
+            <div class='mb-4'>
+                <a href='/' class='inline-flex items-center gap-2 text-zinc-700 dark:text-zinc-300 hover:text-zinc-950 dark:hover:text-zinc-100 transition-colors'>
+                    <svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+                        <path d='M19 12H5M12 19l-7-7 7-7'></path>
+                    </svg>
+                    Home
+                </a>
+            </div>
             <h1 class='text-3xl font-bold mb-2'>{title}</h1>
             <p class='text-zinc-700 dark:text-zinc-300 text-lg'>{description}</p>
         </div>

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -44,6 +44,14 @@ const currentPage = 1;
 <BaseLayout title={title} description={description}>
 	<div class='container'>
 		<div class='mb-10'>
+			<div class='mb-4'>
+				<a href='/' class='inline-flex items-center gap-2 text-zinc-700 dark:text-zinc-300 hover:text-zinc-950 dark:hover:text-zinc-100 transition-colors'>
+					<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'>
+						<path d='M19 12H5M12 19l-7-7 7-7'></path>
+					</svg>
+					Home
+				</a>
+			</div>
 			<h1 class='text-3xl font-bold mb-2'>{title}</h1>
 			<p class='text-zinc-700 dark:text-zinc-300 text-lg'>{description}</p>
 		</div>


### PR DESCRIPTION
This change removes the entire header component (including photo, navigation links, GitHub link, and dark mode toggle) and adds home navigation links throughout the site. The homepage now features a "Home" link where "Posts" used to be, while the posts archive pages and individual blog posts include back-to-home navigation links. 

Mobile viewport spacing has been fixed to eliminate unwanted white space at the top, and all navigation links are properly aligned with their respective content areas.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>