### PR TITLE
fix: footer text alignment to the left and right

### DIFF
--- a/src/layouts/components/Footer.astro
+++ b/src/layouts/components/Footer.astro
@@ -3,14 +3,14 @@ const today = new Date();
 ---
 
 <footer class='container mt-8'>
-	<div class='justify-left flex gap-4 py-8 prose dark:prose-invert text-sm'>
+	<div class='py-8 prose dark:prose-invert text-sm'>
 		<a href='/rss.xml'>RSS</a>
 	</div>
 
 	<div class='py-4 border-t dark:border-t-zinc-700'>
-		<div class='md:flex text-sm text-zinc-500 dark:text-zinc-300 prose dark:prose-invert justify-between'>
-			<div>Copyright © {today.getFullYear()} Arun.</div>
-			<div>
+		<div class='md:flex text-sm text-zinc-500 dark:text-zinc-300 justify-between'>
+			<div class='text-left'>Copyright © {today.getFullYear()} Arun.</div>
+			<div class='text-right'>
 				I am not a frontend guy. Design <a href='https://github.com/devaradise/devolio' target='_blank' rel='nofollow noopener'
 					>devolio by devaradise</a
 				>


### PR DESCRIPTION
Fixes footer text alignment by left-aligning the RSS link, copyright text, and properly positioning the design credit text to the right corner. Removes conflicting prose classes that were interfering with text alignment and ensures the footer elements are positioned correctly across different screen sizes.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>