### PR TITLE
Fix code block highlighting for light mode

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,12 +111,20 @@
 		padding: 1rem;
 		margin: 1.5rem 0;
 		border-radius: 0.5rem;
-		background-color: #1e1e1e;
-		color: #d4d4d4;
+		background-color: #f5f5f5;
+		color: #24292e;
 		white-space: pre-wrap !important;
 		word-wrap: break-word !important;
 		max-width: 100%;
 		overflow-x: hidden !important;
+	}
+
+	/* Dark mode code blocks */
+	@media (prefers-color-scheme: dark) {
+		pre {
+			background-color: #1e1e1e;
+			color: #d4d4d4;
+		}
 	}
 
 	/* Remove scrollbars */
@@ -144,22 +152,46 @@
 }
 
 /* Syntax highlighting - outside of @layer to ensure it takes precedence */
+/* Light mode syntax highlighting */
 pre .token.tag {
-	color: #569cd6;
+	color: #116329;
 }
 
 pre .token.attr-name {
-	color: #9cdcfe;
+	color: #0550ae;
 }
 
 pre .token.attr-value {
-	color: #ce9178;
+	color: #0a3069;
 }
 
 pre .token.string {
-	color: #ce9178;
+	color: #0a3069;
 }
 
 pre .token.punctuation {
-	color: #d4d4d4;
+	color: #24292e;
+}
+
+/* Dark mode syntax highlighting */
+@media (prefers-color-scheme: dark) {
+	pre .token.tag {
+		color: #569cd6;
+	}
+
+	pre .token.attr-name {
+		color: #9cdcfe;
+	}
+
+	pre .token.attr-value {
+		color: #ce9178;
+	}
+
+	pre .token.string {
+		color: #ce9178;
+	}
+
+	pre .token.punctuation {
+		color: #d4d4d4;
+	}
 }


### PR DESCRIPTION
## Summary
- Fixed code block background and text colors to properly support light mode
- Added light mode syntax highlighting token colors for better readability
- Maintained existing dark mode appearance with proper media queries

## Changes
- Light mode code blocks now use light gray background (#f5f5f5) with dark text (#24292e)
- Added GitHub-inspired syntax highlighting colors for light mode
- Kept VS Code-inspired colors for dark mode

## Test Plan
- [x] Test code blocks in light mode for readability
- [x] Test code blocks in dark mode to ensure no regression
- [x] Verify syntax highlighting tokens display correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)